### PR TITLE
Add explicitClose option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased][]
 
+### Added
+
+-   `explicitClose` option for disabling modal close when clicking on modal
+    backdrop or when pressing `esc` key
+
 ## [1.1.1][] - 2019-12-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 -   `explicitClose` option for disabling modal close when clicking on modal
-    backdrop or when pressing `esc` key
+    backdrop or when pressing `Escape` key
 
 ## [1.1.1][] - 2019-12-19
 

--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ Useful if you want to create additional styling/functionality selector hook.
 
 ##### explicitClose
 
-Type: `boolean` Default: `false`
+Type: `boolean`  
+Default: `false`
 
-Option for disabling modal instance close on `esc` key press, or when modal
+Option for disabling modal instance close on `Escape` key press, or when modal
 backdrop is clicked.
 
 ### instance.show()

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Features:
 
 -   Best accessibility practices baked in
 -   Tab and focus lock on tabbable elements inside dialog
--   Handles usual UX considerations such as closing on Escape key and clicking on dialog backdrop
+-   Handles usual UX considerations such as closing on Escape key and clicking
+    on dialog backdrop
 -   Flexible styling
 -   Sets `aria-hidden` on all sibling and ancestor elements except for the
     currently active dialog which traps the virtual cursor inside the dialog
@@ -95,6 +96,13 @@ Default: ``
 HTML class namespace in addition to default one (`statua-Dialog`).
 
 Useful if you want to create additional styling/functionality selector hook.
+
+##### explicitClose
+
+Type: `boolean` Default: `false`
+
+Option for disabling modal instance close on `esc` key press, or when modal
+backdrop is clicked.
 
 ### instance.show()
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ export default (options = {}) => {
 		onCreate = () => {},
 		onDestroy = () => {},
 		onShow = () => {},
-		onClose = () => {}
+		onClose = () => {},
+		explicitClose = false
 	} = options;
 
 	if (content instanceof TypeError) {
@@ -22,7 +23,8 @@ export default (options = {}) => {
 			onCreate,
 			onDestroy,
 			onShow,
-			onClose
+			onClose,
+			explicitClose
 		}
 	});
 

--- a/lib/index.svelte
+++ b/lib/index.svelte
@@ -134,8 +134,10 @@ export default {
 			const keycode = event.which;
 			const target = event.target;
 			const { isHidden } = this.get();
+			const { explicitClose } = this.get();
 			if (
 				!isHidden &&
+				!explicitClose &&
 				isMouseClick(keycode) &&
 				target !== this.refs.dialog &&
 				!this.refs.dialog.contains(target) &&
@@ -147,7 +149,12 @@ export default {
 		},
 		handleGlobalKeyboardEvent(event) {
 			const keycode = event.which;
-			if (keycode === KEY_ESCAPE && dialogInstanceStack.length !== 0) {
+			const { explicitClose } = this.get();
+			if (
+				!explicitClose &&
+				keycode === KEY_ESCAPE &&
+				dialogInstanceStack.length !== 0
+			) {
 				const { id } = this.get();
 				const [stackId] = dialogInstanceStack[
 					dialogInstanceStack.length - 1

--- a/test/index.js
+++ b/test/index.js
@@ -66,6 +66,26 @@ it('should close instance when pressing Escape key', function() {
 	}
 });
 
+it('should leave instance open if explicitClose is true and Escape key is pressed', function() {
+	const instance = fn({
+		content: /* HTML */ `
+			<div class="becky">becky</div>
+		`,
+		explicitClose: true
+	});
+	instance.show();
+
+	try {
+		assert.ok(nodesExist(['.statua-Dialog-content[role="dialog"] .becky']));
+
+		pressEscape(document.body);
+
+		assert.ok(!nodesExist(['.statua-Dialog.is-hidden']));
+	} finally {
+		instance.destroy();
+	}
+});
+
 it('should close instance when clicking outside dialog', function() {
 	const instance = fn({
 		content: /* HTML */ `
@@ -89,6 +109,31 @@ it('should close instance when clicking outside dialog', function() {
 				'.statua-Dialog.is-hidden .statua-Dialog-content[role="dialog"] .becky'
 			])
 		);
+	} finally {
+		instance.destroy();
+	}
+});
+
+it('should leave instance open when clicking outside dialog if explicitClose is true', function() {
+	const instance = fn({
+		content: /* HTML */ `
+			<div class="becky">becky</div>
+		`,
+		explicitClose: true
+	});
+	instance.show();
+
+	const element = document.querySelector('.statua-Dialog');
+	const outsideElement = document.querySelector('.statua-Dialog-backdrop');
+
+	try {
+		mouseClick(element);
+
+		assert.ok(nodesExist(['.statua-Dialog-content[role="dialog"] .becky']));
+
+		mouseClick(outsideElement);
+
+		assert.ok(!nodesExist(['.statua-Dialog.is-hidden']));
 	} finally {
 		instance.destroy();
 	}


### PR DESCRIPTION
Adding explicitClose option. If true, it disables modal close on `esc` key press or clicking on modal backdrop.